### PR TITLE
Fixes for object wrapping in 'bdate' dropdown in client/main.less.

### DIFF
--- a/client/main.less
+++ b/client/main.less
@@ -55,7 +55,7 @@ h1 img.dl-icon {
     margin-bottom: .25rem!important;
 }
 .dropdown-menu {
-	white-space: nowrap;
+	// white-space: nowrap; // When removed, fixes item wrapping in bdate dropdown menu - Darren Moody
 	max-width: 400px;
 
 	a.li-notification {


### PR DESCRIPTION
This branch fixes the issue with object wrapping in the bdate date-picker drop-down in the user-profile settings page. Link to Trello card: https://trello.com/c/Z46Ccw2D/508-birth-date-drop-down-menu-for-choosing-year-and-month-needs-to-be-expanded 