### PR TITLE
Qnaire/lock answered questions

### DIFF
--- a/imports/api/qnaire/methods.js
+++ b/imports/api/qnaire/methods.js
@@ -13,5 +13,12 @@ Meteor.methods({
     'qnaire.DeleteQuestion'(qnaireId, label) {
         let q = Qnaire.findOne({ _id: qnaireId })
         q.deleteQuestion(qnaireId, label)
+    },
+    'qnaire.checkEditDisabled' (qnrid, label) {
+        console.log('im running checkEditDisabled')
+        console.log(qnrid)
+        console.log(label)
+        let q = Qnaire.findOne({ _id: qnrid })
+        q.disableQuestionEdit(label)
     }
 });

--- a/imports/api/qnaire/qnaire.js
+++ b/imports/api/qnaire/qnaire.js
@@ -212,7 +212,21 @@ const Qnaire = Class.create({
                     return;
                 }
             }
-        }
+        },
+        disableQuestionEdit(qnrid, label) {
+
+            let qnaire = Qnaire.findOne({ _id: qnrid })
+            const index = qnaire.questions.findIndex((question) => question.label === label)
+
+            if (index !== -1) {
+                let flagStatus = qnaire.questions[index].canEdit
+                if (flagStatus === false) return 
+                if (flagStatus === true) {
+                    flagStatus = false
+                    Qnaire.update({ _id: qnrid }, { $set: { "questions": qnaire.questions } })
+                }   
+            }
+        },
     }
 });
 

--- a/imports/api/qnaire/qnaire.js
+++ b/imports/api/qnaire/qnaire.js
@@ -31,6 +31,10 @@ const QQuestion = Class.create({
             type: String,
             default: ""
         },
+        canEdit: {
+            type: Boolean, 
+            default: true
+        },
         onAnswered: {
             type: String,
             default: ""

--- a/imports/api/qnaire/qnaire.js
+++ b/imports/api/qnaire/qnaire.js
@@ -213,17 +213,15 @@ const Qnaire = Class.create({
                 }
             }
         },
-        disableQuestionEdit(qnrid, label) {
-
-            let qnaire = Qnaire.findOne({ _id: qnrid })
-            const index = qnaire.questions.findIndex((question) => question.label === label)
-
+        disableQuestionEdit(label) {
+            const index = this.questions.findIndex((question) => question.label === label)
+            console.log(`INDEX:  ${index}`)
             if (index !== -1) {
-                let flagStatus = qnaire.questions[index].canEdit
-                if (flagStatus === false) return 
-                if (flagStatus === true) {
-                    flagStatus = false
-                    Qnaire.update({ _id: qnrid }, { $set: { "questions": qnaire.questions } })
+                let flagStatus = this.questions[index].canEdit
+                console.log(`FLAG STATUS:  ${flagStatus}`)
+                if (flagStatus) {
+                    this.questions[index].canEdit = false
+                    this.save()
                 }   
             }
         },

--- a/imports/ui/pages/qnaire/qnaire.js
+++ b/imports/ui/pages/qnaire/qnaire.js
@@ -203,6 +203,10 @@ Template.qnaire.events({
 				FlowRouter.go("/dashboard");
             }
         });
+        
+        let label = Qnaire.findOne({ "_id": instance.qnrid() }).questions[instance.qnrpage() - 1].label
+        let qnaireId = instance.qnrid()
+        Meteor.call('qnaire.checkEditDisabled', qnaireId, label)
 	},
     'click button#continue'(event, instance) {
 		//carls code
@@ -244,6 +248,10 @@ Template.qnaire.events({
         	}
 
         });
+
+        let label = Qnaire.findOne({ "_id": instance.qnrid() }).questions[instance.qnrpage() - 1].label
+        let qnaireId = instance.qnrid()
+        Meteor.call('qnaire.checkEditDisabled', qnaireId, label)
     }
 },{}
 );

--- a/imports/ui/pages/qnaire_build/qnaire_build.html
+++ b/imports/ui/pages/qnaire_build/qnaire_build.html
@@ -58,9 +58,9 @@
 </template>
 
 <template name="qinput">
-    <div class="q" data-label="{{question.label}}">
+    <div class="q" data-label="{{question.label}}" data-editable="{{question.canEdit}}">
         <div class="checkbox">
-            <label><input id="q-{{question._id}}-disable" name="deactivated" class="q-checkbox" type="checkbox" data-flag="{{question.canEdit}}">Deactivate Question:</label>
+            <label><input id="q-{{question._id}}-disable" name="deactivated" class="q-checkbox" type="checkbox">Deactivate Question:</label>
         </div>
         <div class="form-group">
             <label for="q-{{question.label}}-label">Label:</label>

--- a/imports/ui/pages/qnaire_build/qnaire_build.html
+++ b/imports/ui/pages/qnaire_build/qnaire_build.html
@@ -59,6 +59,9 @@
 
 <template name="qinput">
     <div class="q" data-label="{{question.label}}">
+        <div class="checkbox">
+            <label><input id="q-{{question._id}}-disable" name="deactivated" class="q-checkbox" type="checkbox" data-flag="{{question.canEdit}}">Deactivate Question:</label>
+        </div>
         <div class="form-group">
             <label for="q-{{question.label}}-label">Label:</label>
             <input id="q-{{question.label}}-label" class="form-control input-qqlabel" type="text" value="{{question.label}}"/>

--- a/imports/ui/pages/qnaire_build/qnaire_build.js
+++ b/imports/ui/pages/qnaire_build/qnaire_build.js
@@ -288,3 +288,16 @@ Template.qinput.helpers({
         }
     }
 });
+
+// on render of the template check if the question has been answered 
+// and disable editing as needed 
+Template.qinput.rendered = function  checkEdit() {
+    let currentQuestion = this.data.question
+    if (currentQuestion.canEdit === false) {
+        $(this.firstNode).children('.form-group').each(function findInputsForQuestion(index, val) {
+            $(val).children(":input").each(function disableInputsForQuestion(index, val) {
+                $(this).prop('disabled', true)
+            })
+        })
+    }
+}


### PR DESCRIPTION
- updates the data model to include a bool representing whether or not the question is editable (it hasn't been answered before yet), and disables the inputs for editing this question in the gui as needed. 

- adds a checkbox for disable functionality.  this functionality is not implemented in this PR, but is still available to the user after a question is edited, so that deactivation is still an option to the user. 

![image](https://user-images.githubusercontent.com/32709270/51200200-0fd14c00-18b6-11e9-970d-15d91f961a08.png)
