### PR TITLE
Qnaire/fix data field label

### DIFF
--- a/imports/api/qnaire/qnaire.js
+++ b/imports/api/qnaire/qnaire.js
@@ -108,7 +108,7 @@ const Qnaire = Class.create({
         },
         addListItem(qlbl, itemVal) {
             for (let i = 0; i < this.questions.length; i++) {
-                if (qlbl === this.questions[i].label) {
+                if (qlbl.toString() === this.questions[i].label) {
                     this.questions[i].list.push(itemVal);
                     this.save();
                     return;

--- a/imports/ui/pages/qnaire_build/qnaire_build.html
+++ b/imports/ui/pages/qnaire_build/qnaire_build.html
@@ -58,33 +58,33 @@
 </template>
 
 <template name="qinput">
-    <div class="q" data-label="{{question.label}}" data-editable="{{question.canEdit}}">
+    <div class="q" data-label="{{formatLabel}}" data-editable="{{question.canEdit}}">
         <div class="checkbox">
             <label><input id="q-{{question._id}}-disable" name="deactivated" class="q-checkbox" type="checkbox">Deactivate Question:</label>
         </div>
         <div class="form-group">
-            <label for="q-{{question.label}}-label">Data Field Label:</label>
-            <input id="q-{{question.label}}-label" class="form-control input-qqlabel" type="text" value="{{question.label}}"/>
+            <label for="q-{{formatLabel}}-label">Data Field Label:</label>
+            <input id="q-{{formatLabel}}-label" class="form-control input-qqlabel" type="text" value="{{question.label}}"/>
         </div>
         <div class="form-group">
-            <label for="q-{{question.label}}-condition">Condition:</label>
-            <input id="q-{{question.label}}-condition" class="form-control input-qqcondition" type="text" value="{{question.condition}}"/>
+            <label for="q-{{formatLabel}}-condition">Condition:</label>
+            <input id="q-{{formatLabel}}-condition" class="form-control input-qqcondition" type="text" value="{{question.condition}}"/>
         </div>
         <div class="form-group">
-            <label for="q-{{question.label}}-text">Question:</label>
-            <textarea id="q-{{question.label}}-text" class="form-control input-qqtext">{{question.text}}</textarea>
+            <label for="q-{{formatLabel}}-text">Question:</label>
+            <textarea id="q-{{formatLabel}}-text" class="form-control input-qqtext">{{question.text}}</textarea>
         </div>
         <div class="form-group">
-            <label for="q-{{question.label}}-type">Type:</label>
-            <select id="q-{{question.label}}-type" class="form-control q-type">
+            <label for="q-{{formatLabel}}-type">Type:</label>
+            <select id="q-{{formatLabel}}-type" class="form-control q-type">
                 {{#each type in types}}
                 <option {{selectedType @index}}>{{type}}</option>
                 {{/each}}
             </select>
         </div>
         <div class="form-group">
-            <label for="q-{{question.label}}-tpl">Widget:</label>
-            <select id="q-{{question.label}}-tpl" class="form-control q-type">
+            <label for="q-{{formatLabel}}-tpl">Widget:</label>
+            <select id="q-{{formatLabel}}-tpl" class="form-control q-type">
                 {{#each tpl in templates}}
                 <option {{selectedTpl tpl}}>{{tpl}}</option>
                 {{/each}}

--- a/imports/ui/pages/qnaire_build/qnaire_build.js
+++ b/imports/ui/pages/qnaire_build/qnaire_build.js
@@ -306,6 +306,10 @@ Template.qinput.helpers({
             return "style='display:none;'";
             break;*/
         }
+    },
+    formatLabel() {
+        let formattedLabel = this.question.label.toString().trim().replace(/\s+/g, '-').toLowerCase()
+        return formattedLabel
     }
 });
 


### PR DESCRIPTION
Description: 
- Fixes issue: when data label field is a number, you can remove but cannot add answers to an already created question

Changes: 
- added a helper for the data label to convert question labels into strings with - instead of spaces for the id's and data fields in the html
- modified addListItem to force qlbl to be a string for comparision when adding a new list item