### PR TITLE
add answer using the enter key 

### DIFF
--- a/imports/ui/pages/qnaire_build/qnaire_build.js
+++ b/imports/ui/pages/qnaire_build/qnaire_build.js
@@ -144,6 +144,19 @@ Template.qnaire_build.events({
         $valInput.val("");
         console.log(qlbl, itemVal);
     },
+    'keypress input.add-list-item-label' (event, instance) {
+        console.log('keys are happening')
+        console.log(event.keyCode)
+        if (event.keyCode === 13) {
+            let addBtn = $(event.target).next().children('.btn-add-item')
+            let answerValue = event.target.value.trim()
+            if (answerValue !== undefined && answerValue.length !== 0 && 
+                answerValue !== '') 
+            {
+                addBtn.click()
+            } 
+        }
+    },
     // update qnaires branch
     'keyup input.input-qqtitle':_.debounce(function (event, instance) {
             let qnr = Qnaire.findOne( {_id:instance.qnrid} );


### PR DESCRIPTION
Changes: 
- added keypress event for the input field with class .add-list-item-label for keyCode 13 (enter) to simulate click if the value of the input is not empty