### PR TITLE
Feature/remove aarc dependency

### DIFF
--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -38,13 +38,6 @@ http {
     upstream padawan {
         server app:3000;
     }
-#	resolver 127.0.0.11;
-#    upstream aarc_fe {
-#        server aarc_frontend:3333;
-#    }
-#    upstream aarc_be {
-#        server aarc_api:8888;
-#    }
     server {
         listen       3002 default_server;
         listen       [::]:3002 default_server;
@@ -60,53 +53,17 @@ http {
         location /authentication {
 				resolver 127.0.0.11 valid=30s;
 				set $upstreamone http://aarc_frontend:3333/;
-				#set $upstreamone http://padawan/;
-				#fastcgi_pass $upstreamone;
 				proxy_pass $upstreamone;
-
-				#resolver 127.0.0.1 valid=30s;
-                #proxy_pass http://aarc_fe/;
-                #proxy_pass http://aarc_frontend:3333/;
-				#rewrite ^/arrc_frontend(.*)$ $1 break;
-				#rewrite ^/arrc_frontend:3333// http://aarc_frontend:3333/;
-				#try_files http://aarc_frontend:3333/ /;
-				#try_files http://aarc_frontend:3333/static;
         }
         location /static {
 				resolver 127.0.0.11 valid=30s;
-				#resolver 127.0.0.11 [::1];
 				set $upstreamtwo aarc_frontend:3333;
-				#set $upstreamtwo http://aarc_frontend:3333/static;
-				#set $upstreamtwo http://aarc_frontend:3333/;
-				#set $upstreamtwo http://padawan/;
-				#fastcgi_pass $upstreamtwo;
-				#proxy_pass $upstreamtwo;
 				proxy_pass http://$upstreamtwo$uri;
-				
-				
-				#resolver 127.0.0.1 valid=30s;
-                #proxy_pass http://aarc_fe/static;
-                #proxy_pass http://aarc_frontend:3333/static;
-				#rewrite ^/arrc_frontend(.*)$ $1 break;
-				#rewrite ^/arrc_frontend:3333// http://aarc_frontend:3333/;
-				#try_files http://aarc_frontend:3333/static /;
-				#try_files http://aarc_frontend:3333/static;
         }
         location /api/v1/ {
 				resolver 127.0.0.11 valid=30s;
-				#set $upstreamthree http://aarc_api:8888/api/v1/;
 				set $upstreamthree http://padawan/;
-				#fastcgi_pass $upstreamthree;
 				proxy_pass $upstreamthree;
-
-
-				#resolver 127.0.0.1 valid=30s;
-                #proxy_pass http://aarc_be/api/v1/;
-                #proxy_pass http://aarc_api:8888/api/v1/;
-				#rewrite ^/arrc_api(.*)$ $1 break;
-				#rewrite ^/aarc_api:8888/api/v1/// http://aarc_api:8888/api/v1/;
-				#try_files http://aarc_api:8888/api/v1/ /;
-				#try_files http://aarc_api:8888/api/v1/;
         }
 
         error_page 404 /404.html;

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -38,7 +38,7 @@ http {
     upstream padawan {
         server app:3000;
     }
-	resolver 127.0.0.11;
+#	resolver 127.0.0.11;
 #    upstream aarc_fe {
 #        server aarc_frontend:3333;
 #    }
@@ -58,19 +58,51 @@ http {
                 proxy_pass http://padawan/;
         }
         location /authentication {
+				resolver 127.0.0.11 valid=30s;
+				set $upstreamone http://aarc_frontend:3333/;
+				#set $upstreamone http://padawan/;
+				#fastcgi_pass $upstreamone;
+				proxy_pass $upstreamone;
+
+				#resolver 127.0.0.1 valid=30s;
                 #proxy_pass http://aarc_fe/;
                 #proxy_pass http://aarc_frontend:3333/;
-				try_files http://aarc_frontend:3333/ /;
+				#rewrite ^/arrc_frontend(.*)$ $1 break;
+				#rewrite ^/arrc_frontend:3333// http://aarc_frontend:3333/;
+				#try_files http://aarc_frontend:3333/ /;
+				#try_files http://aarc_frontend:3333/static;
         }
         location /static {
+				resolver 127.0.0.11 valid=30s;
+				#set $upstreamtwo http://aarc_frontend:3333/static;
+				#set $upstreamtwo http://padawan/;
+				#fastcgi_pass $upstreamtwo;
+				#proxy_pass $upstreamtwo;
+				
+				
+				#resolver 127.0.0.1 valid=30s;
                 #proxy_pass http://aarc_fe/static;
-                #proxy_pass http://aarc_frontend:3333/static;
-				try_files http://aarc_frontend:3333/static /;
+                proxy_pass http://aarc_frontend:3333/static;
+				#rewrite ^/arrc_frontend(.*)$ $1 break;
+				#rewrite ^/arrc_frontend:3333// http://aarc_frontend:3333/;
+				#try_files http://aarc_frontend:3333/static /;
+				#try_files http://aarc_frontend:3333/static;
         }
         location /api/v1/ {
+				resolver 127.0.0.11 valid=30s;
+				#set $upstreamthree http://aarc_api:8888/api/v1/;
+				set $upstreamthree http://padawan/;
+				#fastcgi_pass $upstreamthree;
+				proxy_pass $upstreamthree;
+
+
+				#resolver 127.0.0.1 valid=30s;
                 #proxy_pass http://aarc_be/api/v1/;
                 #proxy_pass http://aarc_api:8888/api/v1/;
-				try_files http://aarc_api:8888/api/v1/ /;
+				#rewrite ^/arrc_api(.*)$ $1 break;
+				#rewrite ^/aarc_api:8888/api/v1/// http://aarc_api:8888/api/v1/;
+				#try_files http://aarc_api:8888/api/v1/ /;
+				#try_files http://aarc_api:8888/api/v1/;
         }
 
         error_page 404 /404.html;

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -48,22 +48,22 @@ http {
         #include /etc/nginx/default.d/*.conf;
 
         location / {
-                proxy_pass http://padawan/;
+            proxy_pass http://padawan/;
         }
         location /authentication {
-				resolver 127.0.0.11 valid=30s;
-				set $upstreamone http://aarc_frontend:3333/;
-				proxy_pass $upstreamone;
+			resolver 127.0.0.11 valid=30s;
+			set $upstreamone http://aarc_frontend:3333/;
+			proxy_pass $upstreamone;
         }
         location /static {
-				resolver 127.0.0.11 valid=30s;
-				set $upstreamtwo aarc_frontend:3333;
-				proxy_pass http://$upstreamtwo$uri;
+			resolver 127.0.0.11 valid=30s;
+			set $upstreamtwo aarc_frontend:3333;
+			proxy_pass http://$upstreamtwo$uri;
         }
         location /api/v1/ {
-				resolver 127.0.0.11 valid=30s;
-				set $upstreamthree http://padawan/;
-				proxy_pass $upstreamthree;
+			resolver 127.0.0.11 valid=30s;
+			set $upstreamthree http://padawan/;
+			proxy_pass $upstreamthree;
         }
 
         error_page 404 /404.html;

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -38,6 +38,7 @@ http {
     upstream padawan {
         server app:3000;
     }
+	resolver 127.0.0.11;
 #    upstream aarc_fe {
 #        server aarc_frontend:3333;
 #    }
@@ -56,15 +57,21 @@ http {
         location / {
                 proxy_pass http://padawan/;
         }
-#        location /authentication {
-#                proxy_pass http://aarc_fe/;
-#        }
-#        location /static {
-#                proxy_pass http://aarc_fe/static;
-#        }
-#        location /api/v1/ {
-#                proxy_pass http://aarc_be/api/v1/;
-#        }
+        location /authentication {
+                #proxy_pass http://aarc_fe/;
+                #proxy_pass http://aarc_frontend:3333/;
+				try_files http://aarc_frontend:3333/ /;
+        }
+        location /static {
+                #proxy_pass http://aarc_fe/static;
+                #proxy_pass http://aarc_frontend:3333/static;
+				try_files http://aarc_frontend:3333/static /;
+        }
+        location /api/v1/ {
+                #proxy_pass http://aarc_be/api/v1/;
+                #proxy_pass http://aarc_api:8888/api/v1/;
+				try_files http://aarc_api:8888/api/v1/ /;
+        }
 
         error_page 404 /404.html;
             location = /40x.html {

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -74,15 +74,19 @@ http {
         }
         location /static {
 				resolver 127.0.0.11 valid=30s;
+				#resolver 127.0.0.11 [::1];
+				set $upstreamtwo aarc_frontend:3333;
 				#set $upstreamtwo http://aarc_frontend:3333/static;
+				#set $upstreamtwo http://aarc_frontend:3333/;
 				#set $upstreamtwo http://padawan/;
 				#fastcgi_pass $upstreamtwo;
 				#proxy_pass $upstreamtwo;
+				proxy_pass http://$upstreamtwo$uri;
 				
 				
 				#resolver 127.0.0.1 valid=30s;
                 #proxy_pass http://aarc_fe/static;
-                proxy_pass http://aarc_frontend:3333/static;
+                #proxy_pass http://aarc_frontend:3333/static;
 				#rewrite ^/arrc_frontend(.*)$ $1 break;
 				#rewrite ^/arrc_frontend:3333// http://aarc_frontend:3333/;
 				#try_files http://aarc_frontend:3333/static /;

--- a/docker/dev/nginx.conf
+++ b/docker/dev/nginx.conf
@@ -38,12 +38,12 @@ http {
     upstream padawan {
         server app:3000;
     }
-    upstream aarc_fe {
-        server aarc_frontend:3333;
-    }
-    upstream aarc_be {
-        server aarc_api:8888;
-    }
+#    upstream aarc_fe {
+#        server aarc_frontend:3333;
+#    }
+#    upstream aarc_be {
+#        server aarc_api:8888;
+#    }
     server {
         listen       3002 default_server;
         listen       [::]:3002 default_server;
@@ -56,15 +56,15 @@ http {
         location / {
                 proxy_pass http://padawan/;
         }
-        location /authentication {
-                proxy_pass http://aarc_fe/;
-        }
-        location /static {
-                proxy_pass http://aarc_fe/static;
-        }
-        location /api/v1/ {
-                proxy_pass http://aarc_be/api/v1/;
-        }
+#        location /authentication {
+#                proxy_pass http://aarc_fe/;
+#        }
+#        location /static {
+#                proxy_pass http://aarc_fe/static;
+#        }
+#        location /api/v1/ {
+#                proxy_pass http://aarc_be/api/v1/;
+#        }
 
         error_page 404 /404.html;
             location = /40x.html {


### PR DESCRIPTION
The feature/removeAarcDependency branch was forked from the branch feature/DevDockerMicroservices. It should allow nginx to run whether or not the aarc server is running or not.